### PR TITLE
Fix line ending issue with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh    text eol=lf
+*.bash    text eol=lf


### PR DESCRIPTION
Resolve #2 by including .gitattributes file that prevents git from changing line endings when cloning on to Windows.  Tip found [here](https://stackoverflow.com/a/66868700)