### PR TITLE
Update for _HOST environment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,16 @@ docker-compose -f docker-compose.windows.yml up
 
 The Gazebo web interface is then available on [localhost:8080](http://localhost:8080).
 
-Any MAVLink compatible GCS can be connected to UDP 14550. Many GCS will do this automatically.
+On Linux, any MAVLink compatible GCS can be connected to UDP 14550. Many GCS will do this automatically.
+
+On Windows, any MAVLink compatible GCS can be connected to TCP 5761.
+
+### Troubleshooting
+
+The simulator needs to download some model files when it is first run so it will likely fail to spawn the vehicle.
+Leave it running for a few minutes then use `Ctrl+C` to exit and run it again. This should allow the model to spawn.
+The first time the model attempts to spawn, the simulator will need to download files for it too so it may be slow to
+start. Subsequent runs should be much faster.
 
 ## Windows and Linux
 

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -2,7 +2,9 @@ version: '3'
 
 services:
   simhost:
-    image: uobflightlabstarling/starling-sim-iris-ap:latest
+    image: uobflightlabstarling/starling-sim-iris-ap:${STARLING_RELEASE:-latest}
+    environment:
+      - AP_SITL_HOST=sitl
     volumes:
       - ./fenswood:/ros.env.d/fenswood
     command: ["ros2", "launch", "/ros.env.d/fenswood/iris.launch.xml"]
@@ -10,26 +12,26 @@ services:
       - "8080:8080"
 
   sitl:
-    image: uobflightlabstarling/starling-sim-ardupilot-copter:latest
+    image: uobflightlabstarling/starling-sim-ardupilot-copter:${STARLING_RELEASE:-latest}
     environment:
       - AP_USE_GAZEBO=true
       - AP_HOME=51.4233628,-2.671671,100.0,0
-    ports:
-      - "18570:18570/udp"
+      - AP_SIM_HOST=simhost
   
   mavros:
-    image: uobflightlabstarling/starling-mavros:latest
+    image: uobflightlabstarling/starling-mavros:${STARLING_RELEASE:-latest}
     command: ros2 launch launch/mavros_bridge.launch.xml
     environment:
       - "MAVROS_TGT_FIRMWARE=apm"
       - "MAVROS_TGT_SYSTEM=1"
-      - "MAVROS_FCU_URL=tcp://127.0.0.1:5760"
+      - "MAVROS_FCU_URL=tcp://sitl:5760"
+      - "MAVROS_GCS_URL=tcp-l://:5761"
       - "MAVROS_CONFIG_PATH=/mavros_config_ap.yaml"
       - "MAVROS_PLUGINLISTS_PATH=/mavros_pluginlists_ap.yaml"
     ports:
-      - "5760:5760"
+      - "5761:5761"
 
   rosbridge-suite:
-    image: uobflightlabstarling/rosbridge-suite:latest
+    image: uobflightlabstarling/rosbridge-suite:${STARLING_RELEASE:-latest}
     ports:
       - "9090:9090"


### PR DESCRIPTION
Uses the `*_HOST` environment variables to configure the `sitl` and `simhost` containers to talk to each other. Additionally puts the MAVLink stream from MAVROS on TCP/5761 and exposes it.

With this change we should be able to go back to a single compose file. Network=host mode is only of interest for bare metal ROS on Linux.

Requires StarlingUAS/ProjectStarling#117 to be merged. Until then, the image version used by the compose file can be configured using

```sh
STARLING_RELEASE=ap-sim-address docker-compose -f docker-compose.windows.yml pull
STARLING_RELEASE=ap-sim-address docker-compose -f docker-compose.windows.yml up
```