### PR TITLE
Fixed error target collision now box instead of cylinder

### DIFF
--- a/fenswood/spawn_targets.py
+++ b/fenswood/spawn_targets.py
@@ -73,7 +73,7 @@ def generate_target_link(root, name, height, width, pos, yaw, z = 0.1, colour="G
     # Collision
     collision = ET.SubElement(link, "collision", name="collision")
     col_geometry = ET.SubElement(collision, "geometry")
-    col_box = ET.SubElement(col_geometry, "cylinder")
+    col_box = ET.SubElement(col_geometry, "box")
     ET.SubElement(col_box, "size").text = f"{height} {width} {model_height}"
 
 def spawn_entity(xml_file_location, location, target_name="target", spawn_timeout=30.0):


### PR DESCRIPTION
This PR closes #17, previously target collision geometry was cylinder, but with the subfield belonging to box (and thus had no valid size). Collision geometry now box, hopefully with valid size subfield.
Needs to be tested, if you have a chance @arthurrichards77 it would be much appreciated! 
If it works feel free to merge.